### PR TITLE
[Feature] Windows Support and Path Overriding by Env Variables (for running test scripts)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,15 +20,30 @@
 
 ## Installation
 
+Linux:
 ```
 git clone https://github.com/bala1144/Imitator.git
 cd Imitator
 bash install.sh
 ```
 
-## Overview of pretrained models
+Windows:
+```
+git clone https://github.com/bala1144/Imitator.git
+cd Imitator
+install.bat
+```
 
-`bash download_asset.sh`
+## Overview of pretrained models
+Linux:
+```
+bash download_asset.sh
+```
+
+Windows:
+```
+download_asset.bat
+```
 
 We will update 3 pretrained models
 - generalized_model_mbp (Generalized model on VOCAset)
@@ -39,7 +54,7 @@ We will update 3 pretrained models
 
 To evaluate the external audio, you can use the demo audio on the `assets/demo/`
 ```
-python imitator/test_model_external_audio.py -m pretrained_model/generalized_model_mbp --audio assets/demo/audio1.wav -t FaceTalk_170731_00024_TA -c 2 -r -d 
+python imitator/test/test_model_external_audio.py -m pretrained_model/generalized_model_mbp_vel --audio assets/demo/audio1.wav -t FaceTalk_170731_00024_TA -c 2 -r -d 
 ```
 - `-a` path to the audio file
 - `-t` specify the subject of the VOCA
@@ -50,17 +65,43 @@ python imitator/test_model_external_audio.py -m pretrained_model/generalized_mod
 ### Testing on VOCA
 To evaluate the generalized/personalized model on VOCA
 ```
-python imitator/test_model_voca.py -m pretrained_model/generalized_model_mbp -r -d
-python imitator/test_model_voca.py -m pretrained_model/subj0024_stg02_04seq -r -d
-python imitator/test_model_voca.py -m pretrained_model/subj0138_stg02_04seq -r -d
+python imitator/test/test_model_voca.py -m pretrained_model/generalized_model_mbp_vel -r -d
+python imitator/test/test_model_voca.py -m pretrained_model/subj0024_stg02_04seq -r -d
+python imitator/test/test_model_voca.py -m pretrained_model/subj0138_stg02_04seq -r -d
 ```
 - `-c` to specify the config of the dataset; edit the imitator/test/data_cfg.yml to point to your dataset path.
 
+### Overriding config file (optional)
+
+The directories of VOCA dataset and wav2vec model might differ from one to one. 
+
+Set environment variables (`VOCASET_PATH`, `WAV2VEC_PATH`) to run test scripts mentioned above, if you find it hard to find or modify config files (*.yaml).
+
+Linux:
+```
+export VOCASET_PATH=<Path to vocaset folder>
+export WAV2VEC_PATH=<Path to wav2vec model folder (e.g. wav2vec2-base-960h)>
+```
+
+Windows:
+```
+set VOCASET_PATH=<Path to vocaset folder>
+set WAV2VEC_PATH=<Path to wav2vec model folder (e.g. wav2vec2-base-960h)>
+```
 ## Data Preparation
 
 ### VOCA
 Download the [VOCA](https://voca.is.tue.mpg.de/) and prepare using the script from [Faceformer](https://github.com/EvelynFan/FaceFormer)
- `python process_voca_data.py`
+```
+git clone https://github.com/EvelynFan/FaceFormer.git
+cd FaceFormer/vocaset
+python process_voca_data.py
+cd ../..
+```
+
+### wav2vec model (optional, for offline use)
+
+Download wav2vec model, for example [wav2vec2-base-960h](https://huggingface.co/facebook/wav2vec2-base-960h) from [HuggingFace](https://huggingface.co/).
 
 ## Training models
 

--- a/download_asset.bat
+++ b/download_asset.bat
@@ -1,0 +1,28 @@
+@echo off
+
+echo In order to run Imitator, you need to download FLAME. Before you continue, you must register and agree to license terms at: https://flame.is.tue.mpg.de
+
+:A
+choice /C yn  /M "I have registered and agreed to the license terms at https://flame.is.tue.mpg.de"
+if %errorlevel%==2 goto A
+
+echo Unzip the mmbp weights
+unzip assets/release/mbp_weights_win03_weight05.zip -d assets/release
+
+echo Downloading assets to run Imitator...
+
+echo Downloading Imitator pretrained model...
+wget "https://keeper.mpdl.mpg.de/f/24e17fa78a4e4830b44a/?dl=1" -O pretrained_model.zip
+echo Extracting pretrained_model...
+unzip pretrained_model.zip
+del pretrained_model.zip
+
+set flame_path=FLAMEModel
+echo Downloading FLAME related assets
+mkdir %flame_path%
+wget "https://keeper.mpdl.mpg.de/f/cf406e4f145f484a958a/?dl=1" -O FLAME.zip
+echo Extracting FLAME...
+unzip FLAME.zip -d %flame_path%
+del FLAME.zip
+
+echo Assets for EMOCA downloaded and extracted.

--- a/imitator/data/data_loader_actor_wise_custom_init.py
+++ b/imitator/data/data_loader_actor_wise_custom_init.py
@@ -58,11 +58,17 @@ def read_data(
     valid_data = []
     test_data = []
 
-    audio_path = os.path.join(os.getenv("HOME"), dataset_root, wav_path)
-    vertices_path = os.path.join(os.getenv("HOME"), dataset_root, vertices_path)
-    processor = Wav2Vec2Processor.from_pretrained("facebook/wav2vec2-base-960h")
+    if os.getenv("VOCASET_PATH"):
+        audio_path = os.path.join(os.getenv("VOCASET_PATH"), wav_path)
+        vertices_path = os.path.join(os.getenv("VOCASET_PATH"), vertices_path)
+        processor = Wav2Vec2Processor.from_pretrained("facebook/wav2vec2-base-960h")
+        template_file = os.path.join(os.getenv("VOCASET_PATH"), template_file)
+    else:
+        audio_path = os.path.join(os.getenv("HOME"), dataset_root, wav_path)
+        vertices_path = os.path.join(os.getenv("HOME"), dataset_root, vertices_path)
+        processor = Wav2Vec2Processor.from_pretrained("facebook/wav2vec2-base-960h")
+        template_file = os.path.join(os.getenv("HOME"), dataset_root, template_file)
 
-    template_file = os.path.join(os.getenv("HOME"), dataset_root, template_file)
     with open(template_file, 'rb') as fin:
         templates = pickle.load(fin,encoding='latin1')
 
@@ -75,7 +81,7 @@ def read_data(
     for subj in all_subjects:
         subjwise_audio_files = glob.glob(os.path.join(audio_path, subj + "*"))
         for wav_path in tqdm(subjwise_audio_files):
-            f = wav_path.split("/")[-1]
+            f = wav_path.replace("\\","/").split("/")[-1]
             if f.endswith("wav"):
                 wav_path = os.path.join(audio_path,f)
             speech_array, sampling_rate = librosa.load(wav_path, sr=16000)

--- a/imitator/models/nn_model.py
+++ b/imitator/models/nn_model.py
@@ -178,7 +178,10 @@ class imitator(nn.Module):
         self.train_subjects = args.train_subjects.split(" ")
         self.dataset = args.dataset
 
-        if hasattr(args, 'wav2vec_model'):
+        if os.getenv('WAV2VEC_PATH'):
+            wav2vec_path = os.getenv('WAV2VEC_PATH')
+            self.audio_encoder = Wav2Vec2Model.from_pretrained(wav2vec_path)
+        elif hasattr(args, 'wav2vec_model'):
             wav2vec_path = os.path.join(os.getenv('HOME'), args.wav2vec_model)
             self.audio_encoder = Wav2Vec2Model.from_pretrained(wav2vec_path)
         else:

--- a/imitator/test/data_cfg.yaml
+++ b/imitator/test/data_cfg.yaml
@@ -12,6 +12,7 @@ data:
     train_subjects_all: "FaceTalk_170728_03272_TA FaceTalk_170904_00128_TA FaceTalk_170725_00137_TA
           FaceTalk_170915_00223_TA FaceTalk_170811_03274_TA FaceTalk_170913_03279_TA
           FaceTalk_170904_03276_TA FaceTalk_170912_03278_TA"
+    default_init_subject: "FaceTalk_170725_00137_TA"
     train_subjects: "FaceTalk_170728_03272_TA FaceTalk_170725_00137_TA FaceTalk_170913_03279_TA FaceTalk_170904_03276_TA"
     sequence_for_training: "1 2"
     # 2 seq x 2 subj x 4 id : Render 16 seqs for train : 30 sec = 8 mins

--- a/imitator/test/test_model_external_audio.py
+++ b/imitator/test/test_model_external_audio.py
@@ -16,12 +16,18 @@ from imitator.utils.init_from_config import instantiate_from_config
 class test_on_audio():
 
     def __init__(self):
-        wav2vec_model = "projects/dataset/voca_face_former/wav2vec2-base-960h"
-        wav2vec_path = os.path.join(os.getenv('HOME'), wav2vec_model)
+        if os.getenv("WAV2VEC_PATH"):
+            wav2vec_path = os.getenv("WAV2VEC_PATH")
+        else:
+            wav2vec_model = "projects/dataset/voca_face_former/wav2vec2-base-960h"
+            wav2vec_path = os.path.join(os.getenv('HOME'), wav2vec_model)
         self.processor = Wav2Vec2Processor.from_pretrained(wav2vec_path)
         self.rh = render_helper()
 
-        template_file = os.path.join(os.getenv("HOME"), "projects/dataset/voca_face_former", "templates.pkl")
+        if os.getenv("VOCASET_PATH"):
+            template_file = os.path.join(os.getenv("VOCASET_PATH"), "templates.pkl")
+        else:
+            template_file = os.path.join(os.getenv("HOME"), "projects/dataset/voca_face_former", "templates.pkl")
         with open(template_file, 'rb') as handle:
             self.templates = pickle.load(handle, encoding='latin1')
 

--- a/imitator/test/test_model_voca.py
+++ b/imitator/test/test_model_voca.py
@@ -20,12 +20,14 @@ def get_latest_checkpoint(ckpt_dir, pre_fix="epoch") -> str:
     :return: latest checkpoint file
     """
     # Find all the every validation checkpoints
-    # print("{}/*{}.ckpt".format(ckpt_dir,pre_fix))
+    print(ckpt_dir, pre_fix)
+    print("{}/{}*.ckpt".format(ckpt_dir,pre_fix))
     list_of_files = glob.glob("{}/{}*.ckpt".format(ckpt_dir,pre_fix))
     # print(list_of_files)
     latest_checkpoint = None
     if list_of_files:
         latest_checkpoint = max(list_of_files, key=os.path.getctime)
+        latest_checkpoint = latest_checkpoint.replace('\\','/')
     print('Best checkpoint', latest_checkpoint)
     return latest_checkpoint
 
@@ -142,10 +144,15 @@ class test_dataset_wise():
             if self.args.render_results:
                 vid_dir = os.path.join(out_dir, "vid")
                 os.makedirs(vid_dir, exist_ok=True)
-                audio_file = os.path.join(os.getenv("HOME"),
-                                          data.data_cfg["dataset_root"],
+                if os.getenv("VOCASET_PATH"):
+                    audio_file = os.path.join(os.getenv("VOCASET_PATH"),
                                           data.data_cfg["wav_path"],
                                           file_name[0])
+                else:
+                    audio_file = os.path.join(os.getenv("HOME"),
+                                            data.data_cfg["dataset_root"],
+                                            data.data_cfg["wav_path"],
+                                            file_name[0])
                 self.rh.visualize_meshes(vid_dir, seq_name, pred.reshape(-1, 5023,3), audio_file)
 
             if self.args.dump_results:

--- a/imitator/utils/render_helper.py
+++ b/imitator/utils/render_helper.py
@@ -1,4 +1,5 @@
 import os
+import sys
 from tqdm import tqdm
 import cv2
 from imitator.utils.util_pyrenderer import Facerender
@@ -77,7 +78,12 @@ class render_helper():
         os.system(ffmpeg_command)
         print("added audio to the video", out_vid_w_audio_file)
 
-        rm_command = ('rm {0} '.format(video_file))
+        if sys.platform.startswith('win'):
+            rm_command = ('del "{0}" '.format(video_file))
+            print(rm_command)
+        else:
+            rm_command = ('rm {0} '.format(video_file))
+        
         os.system(rm_command)
         print("removed ", video_file)
 

--- a/install.bat
+++ b/install.bat
@@ -1,0 +1,25 @@
+@echo off
+
+set env_name=imitator
+CALL conda remove -n %env_name% --all
+
+echo Creating conda environment
+CALL conda create -n %env_name% python=3.8.5
+CALL conda activate %env_name%
+
+echo %CONDA_PREFIX% | findstr /C:%env_name% >nul
+if errorlevel 1 (
+    echo Conda environment not activated. Probably it was not created successfully for some reason. Please activate the conda environment before running this script
+    exit 1
+) else (
+    echo Conda environment successfully activated
+)
+
+
+echo Installing conda packages
+echo Installing pytorch
+call conda install pytorch==1.10.0 torchvision==0.11.0 torchaudio==0.10.0 cudatoolkit=10.2 -c pytorch
+
+call conda env update -n %env_name% --file environment.yml
+call pip install smplx
+echo Installation finished


### PR DESCRIPTION
1. Windows Support: `install.bat`, `download_asset.bat` and path string conversion code in relevant files.
2. Path Overriding by Env Variables: `VOCASET_PATH` and `WAV2VEC_PATH` can be set to override configs for convience of running test scripts.
3. Add "data/default_init_subject" in file `imitator/test/data_cfg.yaml`, or the script would fail to run.
4. Add relevant text in `README.md` and fix wrong file paths.